### PR TITLE
Cleaner npm scripts with standard linting built in ☘

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# We recommend you to keep these unchanged
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "Babel 6.x plugin to add instrument code with Istanbul-compatible `__coverage__` variable.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "NODE_ENV=development ./node_modules/.bin/babel src -d lib",
-    "clean": "rm -rf lib; rm -rf lib-cov",
-    "mocha": "env NODE_ENV=test BABEL_PLUGIN__COVERAGE__TEST=1 nyc -r lcov -r text mocha",
-    "prepublish": "npm run clean && npm run build",
-    "test": "npm run clean && npm run build && env BABEL_DISABLE_CACHE=1 ./node_modules/.bin/babel src --plugins $(pwd)/lib/index -d lib-cov && npm run mocha"
+    "prebuild": "npm run clean",
+    "build": "cross-env NODE_ENV=development babel src -d lib",
+    "clean": "rimraf lib/ lib-cov/",
+    "lint": "standard src/** test.js",
+    "premocha": "cross-env BABEL_DISABLE_CACHE=1 babel src --plugins $(pwd)/lib/index -d lib-cov",
+    "mocha": "cross-env NODE_ENV=test BABEL_PLUGIN__COVERAGE__TEST=1 nyc -r lcov -r text mocha",
+    "prepublish": "npm test",
+    "pretest": "npm run lint && npm run build",
+    "test": "npm run mocha"
   },
   "author": "Thai Pangsakulyanont <org.yi.dttvb@gmail.com> (http://dt.in.th/)",
   "license": "MIT",
@@ -28,11 +32,13 @@
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.5.2",
     "codecov": "^1.0.1",
+    "cross-env": "^1.0.7",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "nyc": "^6.1.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
+    "rimraf": "^2.5.2",
     "standard": "^6.0.7"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,8 @@ module.exports = function ({ types: t }) {
   function increase (context, type, id, index) {
     const wrap = (index != null
       // If `index` present, turn `x` into `x[index]`.
-      ? x => t.memberExpression(x, t.numericLiteral(index), true)
-      : x => x
+      ? (x) => t.memberExpression(x, t.numericLiteral(index), true)
+      : (x) => x
     )
     return t.unaryExpression('++',
       wrap(
@@ -231,8 +231,8 @@ module.exports = function ({ types: t }) {
   function coverSwitchStatement (path) {
     if (!path.node.loc) return
     instrumentStatement(this, path)
-    const validCases = path.get('cases').filter(p => p.node.loc)
-    const id = nextBranchId(this, path.node.loc.start.line, 'switch', validCases.map(p => p.node.loc))
+    const validCases = path.get('cases').filter((p) => p.node.loc)
+    const id = nextBranchId(this, path.node.loc.start.line, 'switch', validCases.map((p) => p.node.loc))
     let index = 0
     for (const p of validCases) {
       if (p.node.test) {
@@ -269,7 +269,7 @@ module.exports = function ({ types: t }) {
     const node = path.node
     const data = getData(this)
     const id = String(data.nextId.f++)
-    const nameOf = namedNode => namedNode && namedNode.id && namedNode.id.name || null
+    const nameOf = (namedNode) => namedNode && namedNode.id && namedNode.id.name || null
     data.base.f[id] = 0
     data.base.fnMap[id] = {
       name: nameOf(nameFunction(path)), // I love Babel!
@@ -334,7 +334,7 @@ module.exports = function ({ types: t }) {
 
   // If the coverage for this file is sealed, make the guarded function noop.
   // It is here to fix some very weird edge case in `fixtures/imports.js`
-  const guard = f => function (path, state) {
+  const guard = (f) => function (path, state) {
     if (skip(state)) return
     if (getData(this).sealed) return
     return f.call(this, path)
@@ -342,11 +342,11 @@ module.exports = function ({ types: t }) {
 
   const coverWith = (process.env.BABEL_PLUGIN__COVERAGE__TEST
     // Defer execution so we can measure coverage easily.
-    ? f => guard(function () { return f().apply(this, arguments) })
+    ? (f) => guard(function () { return f().apply(this, arguments) })
     // Execute immediately so it runs faster at runtime.
     // NOTE: This case should have already been covered due to
     //       self-instrumentation to generate `lib-cov`.
-    : f => guard(f())
+    : (f) => guard(f())
   )
 
   return {


### PR DESCRIPTION
Here's an easy one @dtinth - this is my suggestion for organizing npm scripts, making them easier to read and follow:
- [standard] linting in `pretest`
- tests must pass before publishing
- cross-platform friendly! :)