### PR TITLE
Replace for of loop with forEach

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,12 +239,12 @@ module.exports = function ({ types: t }) {
     const validCases = path.get('cases').filter((p) => p.node.loc)
     const id = nextBranchId(this, path.node.loc.start.line, 'switch', validCases.map((p) => p.node.loc))
     let index = 0
-    for (const p of validCases) {
+    validCases.forEach(p => {
       if (p.node.test) {
         instrumentStatement(this, p.get('test'))
       }
       p.node.consequent.unshift(increase(this, 'b', id, index++))
-    }
+    })
   }
 
   //


### PR DESCRIPTION
[`babel-plugin-transform-es2015-for-of`](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-for-of) relies on ES6 `Symbol.iterator` which isn't available in Node v0.10.

This change eliminates the only for of loop and thus makes the plugin compatible with Node v0.10.