### PR TITLE
Run _cover__ on load of a file to initialize __coverage__

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const coverageTemplate = template(`
     coverageData.hash = hash
     return coverage[path] = coverageData
   }
+  COVER ()
 `)
 
 //


### PR DESCRIPTION
I have a project where I want to see the coverage for the entire project and not only files that are used in the tests. I achieve this by including all `src` files when running my tests with Webpack and Karma. 

Without this change something inside the file needs to be invoked in one way or another to get any coverage for that file at all. This modification makes sure that all files that are required in the test run have coverage, even if nothing is invoked.