### PR TITLE
feat: respect nyc's include/exclude configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "*"
     ],
     "sourceMap": false,
-    "instrumenter": "./lib/instrumenters/noop"
+    "instrument": false
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -37,7 +37,7 @@
     "cross-env": "^1.0.7",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
-    "nyc": "^6.5.0",
+    "nyc": "^6.6.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   ],
   "nyc": {
     "include": [
-      "/"
-    ]
+      "*"
+    ],
+    "sourceMap": false,
+    "instrumenter": "./lib/instrumenters/noop"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -35,7 +37,7 @@
     "cross-env": "^1.0.7",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
-    "nyc": "^6.1.1",
+    "nyc": "^6.5.0",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "babel-helper-function-name": "^6.5.0",
     "babel-template": "^6.8.0",
-    "require-main-filename": "^1.0.1",
     "test-exclude": "^1.1.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   },
   "dependencies": {
     "babel-helper-function-name": "^6.5.0",
-    "babel-template": "^6.8.0"
+    "babel-template": "^6.8.0",
+    "require-main-filename": "^1.0.1",
+    "test-exclude": "^1.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ import nameFunction from 'babel-helper-function-name'
 import { realpathSync } from 'fs'
 import { createHash } from 'crypto'
 import testExclude from 'test-exclude'
-import requireMainFilename from 'require-main-filename'
 
 const coverageTemplate = template(`
   var FILE_COVERAGE
@@ -39,7 +38,7 @@ function nycShouldInstrument (filename) {
   if (!exclude) {
     exclude = testExclude({
       configKey: 'nyc',
-      configPath: requireMainFilename(require)
+      configPath: process.cwd()
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -138,22 +138,22 @@ describe('test', function () {
         {
           const instrumentedCode = instrument(
             'var a = 1',
-            '/tests/no_override'
+            'tests/no_override.js'
           )
           eval(instrumentedCode)
-          assert.equal(__coverage__['/tests/no_override'].s['1'], 1)
-          assert.equal(__coverage__['/tests/no_override'].s['2'], undefined)
+          assert.equal(__coverage__['tests/no_override.js'].s['1'], 1)
+          assert.equal(__coverage__['tests/no_override.js'].s['2'], undefined)
         }
         {
           const instrumentedCode = instrument(
             'var a = 1',
-            '/tests/no_override'
+            'tests/no_override.js'
           )
           eval(instrumentedCode)
-          assert.equal(__coverage__['/tests/no_override'].s['1'], 2)
+          assert.equal(__coverage__['tests/no_override.js'].s['1'], 2)
         }
       } finally {
-        delete __coverage__['/tests/no_override']
+        delete __coverage__['tests/no_override.js']
       }
     })
 
@@ -169,23 +169,23 @@ describe('test', function () {
         {
           const instrumentedCode = instrument(
             'var a = 1',
-            '/tests/yes_override'
+            'tests/yes_override.js'
           )
           eval(instrumentedCode)
-          assert.equal(__coverage__['/tests/yes_override'].s['1'], 1)
-          assert.equal(__coverage__['/tests/yes_override'].s['2'], undefined)
+          assert.equal(__coverage__['tests/yes_override.js'].s['1'], 1)
+          assert.equal(__coverage__['tests/yes_override.js'].s['2'], undefined)
         }
         {
           const instrumentedCode = instrument(
             'var a = 1; var b = 1',
-            '/tests/yes_override'
+            'tests/yes_override.js'
           )
           eval(instrumentedCode)
-          assert.equal(__coverage__['/tests/yes_override'].s['1'], 1)
-          assert.equal(__coverage__['/tests/yes_override'].s['2'], 1)
+          assert.equal(__coverage__['tests/yes_override.js'].s['1'], 1)
+          assert.equal(__coverage__['tests/yes_override.js'].s['2'], 1)
         }
       } finally {
-        delete __coverage__['/tests/yes_override']
+        delete __coverage__['tests/yes_override.js']
       }
     })
   })


### PR DESCRIPTION
I've [abstracted `nyc`'s `include`/`exclude`](https://github.com/bcoe/test-exclude) logic so that it will be respected when `babel_plugin-__coverage__` is used rather than `istanbul` for instrumentation.

Once we land https://github.com/bcoe/nyc/pull/268 you will be able to use the following configuration to your project to use `__coverage__` and `nyc` in conjunction:

```json
  "nyc": {
    "include": [
      "index.js"
    ],
    "require": [
      "babel-register"
    ],
    "reporter": [
      "lcov",
      "text"
    ],
    "sourceMap": false,
    "instrument": false
  }
```

This:

* turns of source-map instrumentation, differing to `__coverage__`.
* turns off instrumentation, differing to `__coverage__`.
* respects the rest of `nyc`'s configuration.

I think this gets us to a place where we could start advocating `__coverge__` in `nyc` rather than the current approach for ES2015 support.