### PR TITLE
fix assignment to rvalue error on switch statements in large files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ module.exports = function ({ types: t }) {
       if (p.node.test) {
         instrumentStatement(this, p.get('test'))
       }
-      p.node.consequent.unshift(increase(this, 'b', id, index++))
+      p.node.consequent.unshift(t.expressionStatement(increase(this, 'b', id, index++)))
     })
   }
 


### PR DESCRIPTION
On switch statements, the increase for the branch counter was a UnaryExpression
that wasn't wrapped in an ExpressionStatement. Hence, this generated code like this:

```
switch () {
  default:
    ++_cover__().b['115'][3]
    ++_cover__().s['467'];
}
```

In large files, where Babel is in deoptimized styling mode, with the following message:

```
"[BABEL] Note: The code generator has deoptimised the styling of "xyz.js" as it exceeds the max of "100KB".
```

This would be quickly followed by:

```
SyntaxError: Assigning to rvalue (73:145) while parsing file: xyz.js
```

This is perhaps due to some special handling of whitespaces as it's the same
error that appears when parsing a statement like `++a ++b;`.

This proposed change ensures that the statement is wrapped in an
ExpressionStatement similar to implementation on:
https://github.com/istanbuljs/istanbul-lib-instrument/blob/4274e38622af84ed9e2229e3dcf9a4d75ef2ec91/src/visitor.js#L361